### PR TITLE
Fix for issue #22

### DIFF
--- a/calculate_movement_wrangler.py
+++ b/calculate_movement_wrangler.py
@@ -192,12 +192,8 @@ def lambda_handler(event, context):
                 previous_period_data[previous_period_data[response_type] == 2]
 
             # Ensure that only rows that exist in both current and previous get picked up.
-            data = \
-                data[data[reference]
-                     .isin(previous_period_data[reference])].dropna()
-            previous_period_data = \
-                previous_period_data[previous_period_data[reference]
-                                     .isin(data[reference])].dropna()
+            data = data[data[reference].isin(previous_period_data[reference])].dropna()
+            previous_period_data = previous_period_data[previous_period_data[reference].isin(data[reference])].dropna()  # noqa e501
 
             # Merged together so it can be sent via the payload to the method
             merged_data = pd.concat([data, previous_period_data])

--- a/calculate_movement_wrangler.py
+++ b/calculate_movement_wrangler.py
@@ -188,6 +188,16 @@ def lambda_handler(event, context):
             # Ensure that only responder_ids with a response
             # type of 2 (returned) get picked up
             data = data[data[response_type] == 2]
+            previous_period_data = \
+                previous_period_data[previous_period_data[response_type] == 2]
+
+            # Ensure that only rows that exist in both current and previous get picked up.
+            data = \
+                data[data[reference]
+                     .isin(previous_period_data[reference])].dropna()
+            previous_period_data = \
+                previous_period_data[previous_period_data[reference]
+                                     .isin(data[reference])].dropna()
 
             # Merged together so it can be sent via the payload to the method
             merged_data = pd.concat([data, previous_period_data])


### PR DESCRIPTION
Issue #22 states:
Aws system has been built using our test data, which includes an input file and a previous period file. These are concat and looped through, if they are not the same length then the movement method has an indexoutofrange error.

The way to solve this will be ensuring only previous period records that have a matching current period record will be joined on. Where there is not a matching current, the previous should be dropped. Conversely where there isnt a matching previous row, the current row should be dropped. (because the whole imputation process works on the difference between previous and current period data for references)

-----------

This fix addresses that by dropping current rows that dont exist in prev, and vice versa.