### PR TITLE
Remove environment vars from calculate factors method

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -154,14 +154,6 @@ functions:
       - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
     tags:
       app: results
-    environment:
-      first_threshold: 3
-      second_threshold: 3
-      third_threshold: 5
-      first_imputation_factor: 1
-      second_imputation_factor: 2
-      third_imputation_factor: 1
-      region_column: region
 
   deploy-calculate-means-wrangler:
     name: es-imputation-calculate-means-wrangler


### PR DESCRIPTION
These were replaced with runtime variables (in the config) instead. It was an oversight to leave them in the yml file as they are no longer used.