### PR TITLE
Apply factors doesn't need to check period

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.devcontainer/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/apply_factors_wrangler.py
+++ b/apply_factors_wrangler.py
@@ -59,9 +59,7 @@ def lambda_handler(event, context):
         # Event vars
         distinct_values = event['RuntimeVariables']["distinct_values"]
         sum_columns = event['RuntimeVariables']["sum_columns"]
-        period_column = event['RuntimeVariables']['period_column']
         factors_parameters = event["RuntimeVariables"]["factors_parameters"]
-        current_period = event["RuntimeVariables"]["period"]
         regionless_code = factors_parameters["RuntimeVariables"]['regionless_code']
         region_column = factors_parameters["RuntimeVariables"]['region_column']
         questions_list = event['RuntimeVariables']['questions_list']

--- a/apply_factors_wrangler.py
+++ b/apply_factors_wrangler.py
@@ -124,10 +124,6 @@ def lambda_handler(event, context):
         )
         logger.info("Successfully merged previous period data with non-responder df")
 
-        # filter factors df to only get current period
-        factors_dataframe = factors_dataframe[
-            factors_dataframe[period_column].astype('str') == str(current_period)]
-
         # Merge the factors onto the non responders
         non_responders_with_factors = pd.merge(
             non_responder_dataframe_with_prev,


### PR DESCRIPTION
Only the current period is used in apply as it is filtered already in the calculate movement step.

P.S. the '.devcontainer' is a directory used by VSCode for debugging docker images, I'll put together a ticket on the backlog to ignore it from all repos including the template.