### PR TITLE
added generic error handling

### DIFF
--- a/add_regionless_method.py
+++ b/add_regionless_method.py
@@ -1,6 +1,7 @@
 import logging
 
 import pandas as pd
+from es_aws_functions import general_functions
 
 
 def lambda_handler(event, context):
@@ -13,12 +14,14 @@ def lambda_handler(event, context):
     """
     current_module = "Add an all-GB regions - Method"
     error_message = ""
-    log_message = ""
     logger = logging.getLogger("AllGB")
     logger.setLevel(10)
+    run_id = 0
     try:
         logger.info("Starting " + current_module)
-
+        # Retrieve run_id before input validation
+        # Because it is used in exception handling
+        run_id = event['RuntimeVariables']['run_id']
         # Get envrionment variables
         json_data = event["json_data"]
         regionless_code = event["regionless_code"]
@@ -36,34 +39,14 @@ def lambda_handler(event, context):
 
         final_output = {"data": final_dataframe.to_json(orient="records")}
 
-    except KeyError as e:
-        error_message = (
-            "Key Error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
     except Exception as e:
-        error_message = (
-            "General Error in "
-            + current_module
-            + " ("
-            + str(type(e))
-            + ") |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             return {"success": False, "error": error_message}
 
     logger.info("Successfully completed module: " + current_module)
     final_output['success'] = True
-    print(final_output)
     return final_output

--- a/add_regionless_wrangler.py
+++ b/add_regionless_wrangler.py
@@ -3,8 +3,7 @@ import logging
 import os
 
 import boto3
-from botocore.exceptions import ClientError, IncompleteReadError
-from es_aws_functions import aws_functions, exception_classes
+from es_aws_functions import aws_functions, exception_classes, general_functions
 from marshmallow import Schema, fields
 
 
@@ -28,7 +27,6 @@ def lambda_handler(event, context):
     """
     current_module = "Add an all-GB region - Wrangler."
     error_message = ""
-    log_message = ""
     logger = logging.getLogger("AllGB")
     logger.setLevel(10)
     # Define run_id outside of try block
@@ -85,7 +83,8 @@ def lambda_handler(event, context):
             "json_data": json.loads(
                 input_data.to_json(orient="records")),
             "regionless_code": regionless_code,
-            "region_column": region_column
+            "region_column": region_column,
+            "RuntimeVariables": {"run_id": run_id}
         }
 
         # Pass the data for processing (adding of the regionless region)
@@ -118,83 +117,12 @@ def lambda_handler(event, context):
         aws_functions.send_sns_message(checkpoint, sns_topic_arn, 'Add a all-GB region.')
         logger.info("Successfully sent message to sns.")
 
-    except AttributeError as e:
-        error_message = (
-            "Bad data encountered in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except ValueError as e:
-        error_message = (
-            "Parameter validation error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except ClientError as e:
-        error_message = (
-            "AWS Error ("
-            + str(e.response["Error"]["Code"])
-            + ") "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except KeyError as e:
-        error_message = (
-            "Key Error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except IncompleteReadError as e:
-        error_message = (
-            "Incomplete Lambda response encountered in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except exception_classes.MethodFailure as e:
-        error_message = e.error_message
-        log_message = "Error in " + method_name + "." \
-            + " | Run_id: " + str(run_id)
     except Exception as e:
-        error_message = (
-            "General Error in "
-            + current_module
-            + " ("
-            + str(type(e))
-            + ") |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             raise exception_classes.LambdaFailure(error_message)
 
     logger.info("Successfully completed module: " + current_module)

--- a/atypicals_method.py
+++ b/atypicals_method.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 import pandas as pd
+from es_aws_functions import general_functions
 
 import imputation_functions as imp_func
 
@@ -15,11 +16,14 @@ def lambda_handler(event, context):
     """
     current_module = "Imputation Atypicals - Method."
     error_message = ""
-    log_message = ""
     logger = logging.getLogger("Atypicals")
+    run_id = 0
     try:
 
         logger.info("Starting " + current_module)
+        # Retrieve run_id before input validation
+        # Because it is used in exception handling
+        run_id = event['RuntimeVariables']['run_id']
 
         input_data = pd.DataFrame(event['json_data'])
         questions_list = event['questions_list']
@@ -44,35 +48,16 @@ def lambda_handler(event, context):
 
         final_output = {"data": json_out}
 
-    except KeyError as e:
-        error_message = (
-            "Key Error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
     except Exception as e:
-        error_message = (
-            "General Error in "
-            + current_module
-            + " ("
-            + str(type(e))
-            + ") |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             return {"success": False, "error": error_message}
 
     logger.info("Successfully completed module: " + current_module)
-    final_output["success"] = True
+    final_output['success'] = True
     return final_output
 
 

--- a/atypicals_wrangler.py
+++ b/atypicals_wrangler.py
@@ -3,8 +3,7 @@ import logging
 import os
 
 import boto3
-from botocore.exceptions import ClientError, IncompleteReadError
-from es_aws_functions import aws_functions, exception_classes
+from es_aws_functions import aws_functions, exception_classes, general_functions
 from marshmallow import Schema, fields
 
 import imputation_functions as imp_func
@@ -32,7 +31,6 @@ def lambda_handler(event, context):
     """
     current_module = "Imputation Atypicals - Wrangler."
     error_message = ""
-    log_message = ""
     logger = logging.getLogger("Atypicals")
     logger.setLevel(10)
     # Define run_id outside of try block
@@ -88,7 +86,8 @@ def lambda_handler(event, context):
 
         payload = {
             "json_data": json.loads(data_json),
-            "questions_list": questions_list
+            "questions_list": questions_list,
+            "RuntimeVariables": {"run_id": run_id}
         }
 
         logger.info("Dataframe converted to JSON")
@@ -123,84 +122,14 @@ def lambda_handler(event, context):
 
         logger.info("Successfully sent message to sns.")
 
-    except AttributeError as e:
-        error_message = (
-            "Bad data encountered in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except ValueError as e:
-        error_message = (
-            "Parameter validation error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except ClientError as e:
-        error_message = (
-            "AWS Error ("
-            + str(e.response["Error"]["Code"])
-            + ") "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except KeyError as e:
-        error_message = (
-            "Key Error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except IncompleteReadError as e:
-        error_message = (
-            "Incomplete Lambda response encountered in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except exception_classes.MethodFailure as e:
-        error_message = e.error_message
-        log_message = "Error in " + method_name + "." \
-            + " | Run_id: " + str(run_id)
     except Exception as e:
-        error_message = (
-            "General Error in "
-            + current_module
-            + " ("
-            + str(type(e))
-            + ") |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             raise exception_classes.LambdaFailure(error_message)
 
     logger.info("Successfully completed module: " + current_module)
+
     return {"success": True, "checkpoint": checkpoint}

--- a/calculate_imputation_factors_method.py
+++ b/calculate_imputation_factors_method.py
@@ -1,6 +1,7 @@
 import logging
 
 import pandas as pd
+from es_aws_functions import general_functions
 
 import imputation_functions as imp_func
 
@@ -15,12 +16,14 @@ def lambda_handler(event, context):
     """
     current_module = "Calculate Factors - Method"
     error_message = ""
-    log_message = ""
     logger = logging.getLogger("CalculateFactors")
     logger.setLevel(10)
+    run_id = 0
     try:
         logger.info("Calculate Factors Method Begun")
-
+        # Retrieve run_id before input validation
+        # Because it is used in exception handling
+        run_id = event['RuntimeVariables']['run_id']
         # set up variables
         factors_parameters = event["factors_parameters"]["RuntimeVariables"]
         questions_list = event["questions_list"]
@@ -79,33 +82,14 @@ def lambda_handler(event, context):
 
         final_output = {"data": factors_dataframe.to_json(orient="records")}
 
-    except KeyError as e:
-        error_message = (
-            "Key Error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
     except Exception as e:
-        error_message = (
-            "General Error in "
-            + current_module
-            + " ("
-            + str(type(e))
-            + ") |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             return {"success": False, "error": error_message}
 
     logger.info("Successfully completed module: " + current_module)
-    final_output["success"] = True
+    final_output['success'] = True
     return final_output

--- a/calculate_imputation_factors_wrangler.py
+++ b/calculate_imputation_factors_wrangler.py
@@ -4,8 +4,7 @@ import os
 
 import boto3
 import pandas as pd
-from botocore.exceptions import ClientError, IncompleteReadError
-from es_aws_functions import aws_functions, exception_classes
+from es_aws_functions import aws_functions, exception_classes, general_functions
 from marshmallow import Schema, fields
 
 import imputation_functions as imp_func
@@ -32,7 +31,7 @@ def lambda_handler(event, context):
     """
     current_module = "Imputation Calculate Factors - Wrangler."
     error_message = ""
-    log_message = ""
+
     logger = logging.getLogger("CalculateFactors")
 
     # Define run_id outside of try block
@@ -95,7 +94,8 @@ def lambda_handler(event, context):
             "data_json": json.loads(data.to_json(orient="records")),
             "questions_list": questions_list,
             "distinct_values": distinct_values,
-            "factors_parameters": factors_parameters
+            "factors_parameters": factors_parameters,
+            "RuntimeVariables": {"run_id": run_id}
         }
 
         # invoke the method to calculate the factors
@@ -137,73 +137,14 @@ def lambda_handler(event, context):
                                        "Imputation - Calculate Factors.")
         logger.info("Successfully sent message to sns.")
 
-    except ValueError as e:
-        error_message = (
-            "Parameter validation error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except ClientError as e:
-        error_message = (
-            "AWS Error ("
-            + str(e.response["Error"]["Code"])
-            + ") "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except KeyError as e:
-        error_message = (
-            "Key Error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except IncompleteReadError as e:
-        error_message = (
-            "Incomplete Lambda response encountered in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except exception_classes.MethodFailure as e:
-        error_message = e.error_message
-        log_message = "Error in " + method_name + "." \
-            + " | Run_id: " + str(run_id)
     except Exception as e:
-        error_message = (
-            "General Error in "
-            + current_module
-            + " ("
-            + str(type(e))
-            + ") |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             raise exception_classes.LambdaFailure(error_message)
 
     logger.info("Successfully completed module: " + current_module)
+
     return {"success": True, "checkpoint": checkpoint}

--- a/calculate_means_method.py
+++ b/calculate_means_method.py
@@ -1,6 +1,7 @@
 import logging
 
 import pandas as pd
+from es_aws_functions import general_functions
 
 import imputation_functions as imp_func
 
@@ -17,12 +18,13 @@ def lambda_handler(event, context):
     """
     current_module = "Means - Method"
     error_message = ""
-    log_message = ""
     logger = logging.getLogger("Means")
-
+    run_id = 0
     try:
         logger.info("Means Method Begun")
-
+        # Retrieve run_id before input validation
+        # Because it is used in exception handling
+        run_id = event['RuntimeVariables']['run_id']
         # Environment variables
         json_data = event["json_data"]
         distinct_values = event["distinct_values"]
@@ -84,33 +86,14 @@ def lambda_handler(event, context):
 
         final_output = {"data": df.to_json(orient="records")}
 
-    except KeyError as e:
-        error_message = (
-            "Key Error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
     except Exception as e:
-        error_message = (
-            "General Error in "
-            + current_module
-            + " ("
-            + str(type(e))
-            + ") |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             return {"success": False, "error": error_message}
 
     logger.info("Successfully completed module: " + current_module)
-    final_output["success"] = True
+    final_output['success'] = True
     return final_output

--- a/calculate_means_wrangler.py
+++ b/calculate_means_wrangler.py
@@ -3,8 +3,7 @@ import logging
 import os
 
 import boto3
-from botocore.exceptions import ClientError, IncompleteReadError
-from es_aws_functions import aws_functions, exception_classes
+from es_aws_functions import aws_functions, exception_classes, general_functions
 from marshmallow import Schema, fields
 
 import imputation_functions as imp_func
@@ -31,7 +30,6 @@ def lambda_handler(event, context):
     """
     current_module = "Imputation Means - Wrangler."
     error_message = ""
-    log_message = ""
     logger = logging.getLogger("Means")
     logger.setLevel(10)
     # Define run_id outside of try block
@@ -92,7 +90,8 @@ def lambda_handler(event, context):
         payload = {
             "json_data": json.loads(data_json),
             "distinct_values": distinct_values,
-            "questions_list": questions_list
+            "questions_list": questions_list,
+            "RuntimeVariables": {"run_id": run_id}
         }
 
         returned_data = lambda_client.invoke(
@@ -123,83 +122,12 @@ def lambda_handler(event, context):
                                        "Imputation - Calculate Means.")
         logger.info("Successfully sent message to sns.")
 
-    except AttributeError as e:
-        error_message = (
-            "Bad data encountered in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except ValueError as e:
-        error_message = (
-            "Parameter validation error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except ClientError as e:
-        error_message = (
-            "AWS Error ("
-            + str(e.response["Error"]["Code"])
-            + ") "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except KeyError as e:
-        error_message = (
-            "Key Error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except IncompleteReadError as e:
-        error_message = (
-            "Incomplete Lambda response encountered in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except exception_classes.MethodFailure as e:
-        error_message = e.error_message
-        log_message = "Error in " + method_name + "." \
-            + " | Run_id: " + str(run_id)
     except Exception as e:
-        error_message = (
-            "General Error in "
-            + current_module
-            + " ("
-            + str(type(e))
-            + ") |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             raise exception_classes.LambdaFailure(error_message)
 
     logger.info("Successfully completed module: " + current_module)

--- a/calculate_movement_wrangler.py
+++ b/calculate_movement_wrangler.py
@@ -4,7 +4,6 @@ import os
 
 import boto3
 import pandas as pd
-from botocore.exceptions import ClientError, IncompleteReadError
 from es_aws_functions import aws_functions, exception_classes, general_functions
 from marshmallow import Schema, fields
 
@@ -35,7 +34,6 @@ def lambda_handler(event, context):
     logger = logging.getLogger(current_module)
     logger.setLevel(10)
     error_message = ''
-    log_message = ''
     checkpoint = 0
     # Define run_id outside of try block
     run_id = 0
@@ -54,7 +52,7 @@ def lambda_handler(event, context):
         config, errors = schema.load(os.environ)
         if errors:
             raise ValueError(f"Error validating environment params: {errors}")
-        logger.info("Vaildated params")
+        logger.info("Validated params")
 
         # Environment Variables
         bucket_name = config['bucket_name']
@@ -146,7 +144,8 @@ def lambda_handler(event, context):
                 "questions_list": questions_list,
                 "current_period": period,
                 "period_column": period_column,
-                "previous_period": previous_period
+                "previous_period": previous_period,
+                "RuntimeVariables": {"run_id": run_id}
             }
 
             logger.info("Successfully created movement columns on the data")
@@ -201,71 +200,16 @@ def lambda_handler(event, context):
 
         logger.info("Successfully sent the SNS message")
 
-    except AttributeError as e:
-        error_message = "Bad data encountered in " \
-                        + current_module + " |- " \
-                        + str(e.args) + " | Request ID: " \
-                        + str(context.aws_request_id) \
-                        + " | Run_id: " + str(run_id)
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-
-    except ValueError as e:
-        error_message = "Parameter validation error in " \
-                        + current_module + " |- " \
-                        + str(e.args) + " | Request ID: " \
-                        + str(context.aws_request_id) \
-                        + " | Run_id: " + str(run_id)
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-
-    except ClientError as e:
-        error_message = "AWS Error (" \
-                        + str(e.response['Error']['Code']) + ") " \
-                        + current_module + " |- " \
-                        + str(e.args) + " | Request ID: " \
-                        + str(context.aws_request_id) \
-                        + " | Run_id: " + str(run_id)
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-
-    except KeyError as e:
-        error_message = "Key Error in " \
-                        + current_module + " |- " \
-                        + str(e.args) + " | Request ID: " \
-                        + str(context.aws_request_id) \
-                        + " | Run_id: " + str(run_id)
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-
-    except IncompleteReadError as e:
-        error_message = "Incomplete Lambda response encountered in " \
-                        + current_module + " |- " \
-                        + str(e.args) + " | Request ID: " \
-                        + str(context.aws_request_id) \
-                        + " | Run_id: " + str(run_id)
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except exception_classes.MethodFailure as e:
-        error_message = e.error_message
-        log_message = "Error in " + method_name + "." \
-                      + " | Run_id: " + str(run_id)
     except Exception as e:
-        error_message = "General Error in " \
-                        + current_module + " (" \
-                        + str(type(e)) + ") |- " \
-                        + str(e.args) + " | Request ID: " \
-                        + str(context.aws_request_id) \
-                        + " | Run_id: " + str(run_id)
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
-
-        if(len(error_message)) > 0:
-            logger.error(log_message)
+        if (len(error_message)) > 0:
+            logger.error(error_message)
             raise exception_classes.LambdaFailure(error_message)
 
     logger.info("Successfully completed module: " + current_module)
+
     return {
         "success": True,
         "checkpoint": checkpoint,

--- a/iqrs_wrangler.py
+++ b/iqrs_wrangler.py
@@ -3,8 +3,7 @@ import logging
 import os
 
 import boto3
-from botocore.exceptions import ClientError, IncompleteReadError
-from es_aws_functions import aws_functions, exception_classes
+from es_aws_functions import aws_functions, exception_classes, general_functions
 from marshmallow import Schema, fields
 
 import imputation_functions as imp_func
@@ -30,7 +29,7 @@ def lambda_handler(event, context):
     """
     current_module = "Imputation IQRS - Wrangler."
     error_message = ""
-    log_message = ""
+
     logger = logging.getLogger("IQRS")
     logger.setLevel(10)
     # Define run_id outside of try block
@@ -88,7 +87,8 @@ def lambda_handler(event, context):
 
         payload = {"data": json.loads(data_json),
                    "distinct_values": distinct_values,
-                   "questions_list": questions_list}
+                   "questions_list": questions_list,
+                   "RuntimeVariables": {"run_id": run_id}}
 
         wrangled_data = lambda_client.invoke(
             FunctionName=method_name,
@@ -118,83 +118,14 @@ def lambda_handler(event, context):
         aws_functions.send_sns_message(checkpoint, sns_topic_arn, 'Imputation - IQRs.')
         logger.info("Successfully sent message to sns.")
 
-    except AttributeError as e:
-        error_message = (
-            "Bad data encountered in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except ValueError as e:
-        error_message = (
-            "Parameter validation error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except ClientError as e:
-        error_message = (
-            "AWS Error ("
-            + str(e.response["Error"]["Code"])
-            + ") "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except KeyError as e:
-        error_message = (
-            "Key Error in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except IncompleteReadError as e:
-        error_message = (
-            "Incomplete Lambda response encountered in "
-            + current_module
-            + " |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except exception_classes.MethodFailure as e:
-        error_message = e.error_message
-        log_message = "Error in " + method_name + "." + " | Run_id: " + str(run_id)
     except Exception as e:
-        error_message = (
-            "General Error in "
-            + current_module
-            + " ("
-            + str(type(e))
-            + ") |- "
-            + str(e.args)
-            + " | Request ID: "
-            + str(context.aws_request_id)
-            + " | Run_id: " + str(run_id)
-        )
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             raise exception_classes.LambdaFailure(error_message)
 
     logger.info("Successfully completed module: " + current_module)
+
     return {"success": True, "checkpoint": checkpoint}

--- a/serverless.yml
+++ b/serverless.yml
@@ -56,6 +56,7 @@ functions:
       individually: true
     layers:
       - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
+      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:dev-es-common-functions:latest
     tags:
       app: results
 
@@ -133,6 +134,7 @@ functions:
       individually: true
     layers:
       - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
+      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:dev-es-common-functions:latest
     tags:
       app: results
 
@@ -169,6 +171,7 @@ functions:
       individually: true
     layers:
       - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
+      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:dev-es-common-functions:latest
     tags:
       app: results
 
@@ -205,6 +208,7 @@ functions:
       individually: true
     layers:
       - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
+      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:dev-es-common-functions:latest
     tags:
       app: results
 
@@ -277,6 +281,7 @@ functions:
       individually: true
     layers:
       - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
+      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:dev-es-common-functions:latest
     tags:
       app: results
 

--- a/tests/test_add_regionless.py
+++ b/tests/test_add_regionless.py
@@ -103,7 +103,8 @@ class TestApplyFactors(unittest.TestCase):
             event = {
                 "json_data": json_content,
                 "regionless_code": 14,
-                "region_column": "region"
+                "region_column": "region",
+                "RuntimeVariables": {"run_id": "run_id"}
             }
 
             output = add_regionless_method.lambda_handler(
@@ -132,7 +133,7 @@ class TestApplyFactors(unittest.TestCase):
                     mock_event,
                     context_object
                 )
-            assert "General Error" in exc_info.exception.error_message
+            assert "'Exception'" in exc_info.exception.error_message
 
     def test_method_general_exception(self):
         input_file = "tests/fixtures/add_regionless_input.json"
@@ -143,7 +144,8 @@ class TestApplyFactors(unittest.TestCase):
                 event = {
                     "json_data": json_content,
                     "regionless_code": 14,
-                    "region_column": "region"
+                    "region_column": "region",
+                    "RuntimeVariables": {"run_id": "run_id"}
                 }
 
                 response = add_regionless_method.lambda_handler(
@@ -153,7 +155,7 @@ class TestApplyFactors(unittest.TestCase):
 
                 assert "success" in response
                 assert response["success"] is False
-                assert """General exception""" in response["error"]
+                assert "'Exception'" in response["error"]
 
     @mock_sqs
     @mock_lambda
@@ -169,7 +171,7 @@ class TestApplyFactors(unittest.TestCase):
                         mock_event,
                         context_object,
                     )
-            assert "Key Error" in exc_info.exception.error_message
+            assert "KeyError" in exc_info.exception.error_message
 
     def test_method_key_error(self):
         with open("tests/fixtures/add_regionless_input.json", "r") as file:
@@ -181,7 +183,7 @@ class TestApplyFactors(unittest.TestCase):
                 event, context_object
             )
 
-            assert """Key Error in""" in response["error"]
+            assert "KeyError" in response["error"]
 
     def test_marshmallow_raises_wrangler_exception(self):
         """
@@ -209,7 +211,7 @@ class TestApplyFactors(unittest.TestCase):
                 add_regionless_wrangler.lambda_handler(
                     mock_event, context_object
                 )
-            assert "AWS Error" in exc_info.exception.error_message
+            assert "ClientError" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_lambda
@@ -231,7 +233,7 @@ class TestApplyFactors(unittest.TestCase):
                             mock_event,
                             context_object,
                         )
-                    assert "Bad data" in exc_info.exception.error_message
+                    assert "AttributeError" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_lambda
@@ -255,7 +257,7 @@ class TestApplyFactors(unittest.TestCase):
                                 mock_event,
                                 context_object,
                             )
-                        assert "Incomplete Lambda response" in \
+                        assert "IncompleteReadError" in \
                                exc_info.exception.error_message
 
     @mock_sqs

--- a/tests/test_apply_factors.py
+++ b/tests/test_apply_factors.py
@@ -145,7 +145,7 @@ class TestApplyFactors(unittest.TestCase):
                     apply_factors_wrangler.lambda_handler(
                         mock_wrangles_event, context_object
                     )
-                assert "General Error in" in exc_info.exception.error_message
+                assert "'Exception'" in exc_info.exception.error_message
 
     @mock_sqs
     def test_catch_method_exception(self):
@@ -169,7 +169,8 @@ class TestApplyFactors(unittest.TestCase):
                                        "Q607_constructional_fill"],
                     "sum_columns": [{"column_name": "Q608_total", "data": {
                         "Q603_concreting_sand": "+",
-                        "Q602_building_soft_sand": "+"}}]
+                        "Q602_building_soft_sand": "+"}}],
+                    "RuntimeVariables": {"run_id": "run_id"}
                 }
                 response = lambda_method_function.lambda_handler(
                     mock_event, context_object
@@ -311,7 +312,8 @@ class TestApplyFactors(unittest.TestCase):
                 "questions_list": ["Q601_asphalting_sand", "Q602_building_soft_sand",
                                    "Q603_concreting_sand", "Q604_bituminous_gravel",
                                    "Q605_concreting_gravel", "Q606_other_gravel",
-                                   "Q607_constructional_fill"]
+                                   "Q607_constructional_fill"],
+                "RuntimeVariables": {"run_id": "run_id"}
             }
             response = lambda_method_function.lambda_handler(
                 mock_event, context_object
@@ -320,24 +322,7 @@ class TestApplyFactors(unittest.TestCase):
             outputdf = pd.read_json(response["data"])
 
             valuetotest = outputdf["Q608_total"].to_list()[0]
-            assert valuetotest == 48293
-
-    @mock_sqs
-    def test_attribute_error_method(self):
-        methodinput = {"potatoes": "seotatop"}
-        with mock.patch.dict(
-            apply_factors_wrangler.os.environ,
-            {"sqs_queue_url": "Itsa Me! Queueio", "generic_var": "Itsa me, vario"},
-        ):
-            mock_event = {
-                "json_data": json.dumps(methodinput),
-                "sum_columns": [{"column_name": "test", "data": {
-                    "Q601_asphalting_sand": "+", "Q602_building_soft_sand": "+"}}]
-            }
-            response = lambda_method_function.lambda_handler(
-                mock_event, context_object
-            )
-            assert response["error"].__contains__("""Input Error""")
+        assert valuetotest == 48293
 
     @mock_sqs
     def test_key_error_method(self):
@@ -350,7 +335,7 @@ class TestApplyFactors(unittest.TestCase):
             response = lambda_method_function.lambda_handler(
                 methodinput, context_object
             )
-            assert response["error"].__contains__("""Key Error""")
+            assert "KeyError" in response["error"]
 
     @mock_sqs
     def test_type_error_method(self):
@@ -359,7 +344,11 @@ class TestApplyFactors(unittest.TestCase):
         methodinput["imputation_factor_Q601_asphalting_sand"] = "MIIIKE!"
         mock_event = {
             "json_data": methodinput.to_json(orient="records"),
-            "distinct_values": ["strata", "region"]
+            "distinct_values": ["strata", "region"],
+            "sum_columns": [{"column_name": "test",
+                             "data": {"Q601_asphalting_sand": "+",
+                                      "Q602_building_soft_sand": "+"}}],
+            "RuntimeVariables": {"run_id": "run_id"}
         }
         with mock.patch.dict(
             apply_factors_wrangler.os.environ,
@@ -368,7 +357,7 @@ class TestApplyFactors(unittest.TestCase):
             response = lambda_method_function.lambda_handler(
                 json.dumps(mock_event), context_object
             )
-            assert response["error"].__contains__("""Bad Data type""")
+            assert response["error"].__contains__("""TypeError""")
 
     @mock_sqs
     def test_marshmallow_raises_wrangler_exception(self):
@@ -459,7 +448,7 @@ class TestApplyFactors(unittest.TestCase):
                             apply_factors_wrangler.lambda_handler(
                                 mock_wrangles_event, context_object
                             )
-                        assert "Incomplete Lambda response" \
+                        assert "IncompleteReadError" \
                                in exc_info.exception.error_message
 
     @mock_sqs
@@ -494,7 +483,7 @@ class TestApplyFactors(unittest.TestCase):
                         mock_wrangles_event, context_object
                     )
 
-                assert "Key Error" in exc_info.exception.error_message
+                assert "KeyError" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_s3
@@ -524,7 +513,7 @@ class TestApplyFactors(unittest.TestCase):
                     apply_factors_wrangler.lambda_handler(
                         mock_wrangles_event, context_object
                     )
-                assert "Bad data" in exc_info.exception.error_message
+                assert "TypeError" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_s3

--- a/tests/test_atypicals.py
+++ b/tests/test_atypicals.py
@@ -113,7 +113,8 @@ class TestClass():
                                    "Q604_bituminous_gravel",
                                    "Q605_concreting_gravel",
                                    "Q606_other_gravel",
-                                   "Q607_constructional_fill"]
+                                   "Q607_constructional_fill"],
+                "RuntimeVariables": {"run_id": "run_id"}
             }
 
             output = atypicals_method.lambda_handler(
@@ -152,7 +153,7 @@ class TestClass():
                     context_object
                 )
 
-            assert "General Error" in exc_info.exception.error_message
+            assert "'Exception'" in exc_info.exception.error_message
 
     def test_method_general_exception(self):
         input_file = "tests/fixtures/atypical_input.json"
@@ -168,7 +169,8 @@ class TestClass():
                                        "Q604_bituminous_gravel",
                                        "Q605_concreting_gravel",
                                        "Q606_other_gravel",
-                                       "Q607_constructional_fill"]
+                                       "Q607_constructional_fill"],
+                    "RuntimeVariables": {"run_id": "run_id"}
                 }
 
                 response = atypicals_method.lambda_handler(
@@ -178,7 +180,7 @@ class TestClass():
 
                 assert "success" in response
                 assert response["success"] is False
-                assert """General exception""" in response["error"]
+                assert "'Exception'" in response["error"]
 
     @mock_sqs
     @mock_lambda
@@ -195,7 +197,7 @@ class TestClass():
                         context_object,
                     )
 
-            assert "Key Error" in exc_info.exception.error_message
+            assert "KeyError" in exc_info.exception.error_message
 
     def test_method_key_error(self):
         with open("tests/fixtures/atypical_input.json", "r") as file:
@@ -208,13 +210,14 @@ class TestClass():
                                        "Q604_bituminous_gravel",
                                        "Q605_concreting_gravel",
                                        "Q606_other_gravel",
-                                       "Q607_constructional_fill"]
+                                       "Q607_constructional_fill"],
+                    "RuntimeVariables": {"run_id": "run_id"}
                      }
             response = atypicals_method.lambda_handler(
                 event, context_object
             )
 
-            assert """Key Error in""" in response["error"]
+            assert "KeyError" in response["error"]
 
     def test_marshmallow_raises_wrangler_exception(self):
         """
@@ -242,7 +245,7 @@ class TestClass():
                 atypicals_wrangler.lambda_handler(
                     mock_event, context_object
                 )
-            assert "AWS Error" in exc_info.exception.error_message
+            assert "ClientError" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_lambda
@@ -263,7 +266,7 @@ class TestClass():
                             mock_event,
                             context_object,
                         )
-                    assert "Bad data" in exc_info.exception.error_message
+                    assert "AttributeError" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_lambda
@@ -285,7 +288,7 @@ class TestClass():
                                 mock_event,
                                 context_object,
                             )
-                        assert "Incomplete Lambda response" \
+                        assert "IncompleteReadError" \
                                in exc_info.exception.error_message
 
     @mock_sqs

--- a/tests/test_calculate_imputation_factors.py
+++ b/tests/test_calculate_imputation_factors.py
@@ -206,7 +206,8 @@ class TestWranglerAndMethod(unittest.TestCase):
                         "regional_mean": "third_imputation_factors"
                     }
                 },
-                "sns_topic_arn": "mock_arn"
+                "sns_topic_arn": "mock_arn",
+                "RuntimeVariables": {"run_id": "run_id"}
             }, context_object
         )
 
@@ -247,7 +248,8 @@ class TestWranglerAndMethod(unittest.TestCase):
                         "survey_column": "survey",
                         "threshold": 7,
                     }},
-                "sns_topic_arn": "mock_arn"
+                "sns_topic_arn": "mock_arn",
+                "RuntimeVariables": {"run_id": "run_id"}
              }, context_object
         )
 
@@ -286,7 +288,8 @@ class TestWranglerAndMethod(unittest.TestCase):
                                 "Q604_bituminous_gravel",
                                 "Q605_concreting_gravel",
                                 "Q606_other_gravel",
-                                "Q607_constructional_fill"]
+                                "Q607_constructional_fill"],
+                "RuntimeVariables": {"run_id": "run_id"}
              }, context_object
         )
         assert not response["success"]
@@ -312,7 +315,8 @@ class TestWranglerAndMethod(unittest.TestCase):
                 '{"movement_Q601_asphalting_sand":0.857614899}]'
             )
             response = calculate_imputation_factors_method.lambda_handler(
-                {"RuntimeVariables": {"checkpoint": 666},
+                {"RuntimeVariables": {"checkpoint": 666,
+                                      "run_id": "runid"},
                  "data_json": json_data_content,
                  "distinct_values": ["strata", "region"],
                  "questions_list": ["Q601_asphalting_sand",
@@ -362,7 +366,8 @@ class TestWranglerAndMethod(unittest.TestCase):
                                           "queue_url": "Earl"}},
                     context_object
                 )
-            assert "Parameter validation error" in exc_info.exception.error_message
+            assert "Error validating environment params" in \
+                   exc_info.exception.error_message
 
     def test_method_key_error_exception(self):
         """
@@ -384,12 +389,13 @@ class TestWranglerAndMethod(unittest.TestCase):
                                                            "Q604_bituminous_gravel",
                                                            "Q605_concreting_gravel",
                                                            "Q606_other_gravel",
-                                                           "Q607_constructional_fill"]
+                                                           "Q607_constructional_fill"],
+                "RuntimeVariables": {"run_id": "run_id"}
              }, context_object
         )
 
         assert not output_file["success"]
-        assert "Key Error" in output_file["error"]
+        assert "KeyError" in output_file["error"]
 
     @mock_sns
     @mock_sqs
@@ -439,7 +445,7 @@ class TestWranglerAndMethod(unittest.TestCase):
                             calculate_imputation_factors_wrangler.lambda_handler(
                                 mock_event, context_object
                             )
-                        assert "Incomplete Lambda response" in \
+                        assert "IncompleteReadError" in \
                                exc_info.exception.error_message
 
     @mock_sns
@@ -454,7 +460,7 @@ class TestWranglerAndMethod(unittest.TestCase):
                 calculate_imputation_factors_wrangler.lambda_handler(
                     mock_event, context_object
                 )
-            assert "Key Error" in exc_info.exception.error_message
+            assert "KeyError" in exc_info.exception.error_message
 
     def test_wrangler_client_error(self):
         with mock.patch.dict(
@@ -471,7 +477,7 @@ class TestWranglerAndMethod(unittest.TestCase):
                     calculate_imputation_factors_wrangler.lambda_handler(
                         mock_event, context_object
                     )
-                assert "AWS Error" in exc_info.exception.error_message
+                assert "ClientError" in exc_info.exception.error_message
 
     @mock_sns
     @mock_sqs

--- a/tests/test_calculate_movement.py
+++ b/tests/test_calculate_movement.py
@@ -37,6 +37,9 @@ mock_event = {
             "location": "Here",
             "incoming_message_group": {
                 "imputation_movement": "bananas"
+            },
+            "RuntimeVariables": {
+                "run_id": "run_id"
             }
 }
 
@@ -61,6 +64,9 @@ mock_event_b = {
             },
             "incoming_message_group": {
                 "imputation_movement": "bananas"
+            },
+            "RuntimeVariables": {
+                "run_id": "run_id"
             }
 }
 
@@ -156,7 +162,7 @@ class TestStringMethods(unittest.TestCase):
                         self, exception_classes.LambdaFailure) as exc_info:
                     calculate_movement_wrangler.lambda_handler(
                         mock_wrangles_event, context_object)
-                assert "General Error" in exc_info.exception.error_message
+                assert "'Exception'" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_lambda
@@ -206,7 +212,8 @@ class TestStringMethods(unittest.TestCase):
                     self, exception_classes.LambdaFailure) as exc_info:
                 calculate_movement_wrangler.lambda_handler(mock_wrangles_event,
                                                            context_object)
-            assert "Parameter validation error" in exc_info.exception.error_message
+            assert "Error validating environment params" in \
+                   exc_info.exception.error_message
 
     @mock_sqs
     @mock_s3
@@ -234,7 +241,7 @@ class TestStringMethods(unittest.TestCase):
                 calculate_movement_wrangler.lambda_handler(
                     mock_wrangles_event, context_object
                 )
-            assert "AWS Error" in exc_info.exception.error_message
+            assert "ClientError" in exc_info.exception.error_message
 
     def test_method_key_error_exception(self):
         output_file = calculate_movement_method.lambda_handler(
@@ -242,4 +249,4 @@ class TestStringMethods(unittest.TestCase):
         )
 
         assert not output_file["success"]
-        assert "Key Error" in output_file["error"]
+        assert "KeyError" in output_file["error"]

--- a/tests/test_calculate_movement_unittest.py
+++ b/tests/test_calculate_movement_unittest.py
@@ -26,7 +26,9 @@ mock_event = {
                        "Q604_bituminous_gravel",
                        "Q605_concreting_gravel",
                        "Q606_other_gravel",
-                       "Q607_constructional_fill"]
+                       "Q607_constructional_fill"],
+    "RuntimeVariables": {
+                        "run_id": "runid"}
 }
 
 mock_wrangles_event = {
@@ -174,7 +176,7 @@ class TestClass(unittest.TestCase):
                 calculate_movement_wrangler.lambda_handler(
                     mock_wrangles_event, context_object
                 )
-            assert "Incomplete Lambda response" in exc_info.exception.error_message
+            assert "IncompleteReadError" in exc_info.exception.error_message
 
     @mock.patch('calculate_movement_wrangler.aws_functions.send_sns_message')
     @mock.patch('calculate_movement_wrangler.aws_functions.save_data')
@@ -200,7 +202,7 @@ class TestClass(unittest.TestCase):
                 calculate_movement_wrangler.lambda_handler(
                     mock_wrangles_event, context_object
                 )
-        assert "Bad data" in exc_info.exception.error_message
+        assert "AttributeError" in exc_info.exception.error_message
 
     @mock.patch('calculate_movement_wrangler.aws_functions.send_sns_message')
     @mock.patch('calculate_movement_wrangler.aws_functions.save_data')
@@ -226,7 +228,7 @@ class TestClass(unittest.TestCase):
             calculate_movement_wrangler.lambda_handler(
                 mock_wrangles_event, context_object
             )
-        assert "Key Error" in exc_info.exception.error_message
+        assert "KeyError" in exc_info.exception.error_message
 
     @mock.patch('calculate_movement_wrangler.' +
                 'aws_functions.send_sns_message')

--- a/tests/test_iqrs.py
+++ b/tests/test_iqrs.py
@@ -118,7 +118,8 @@ class TestWranglerAndMethod():
                                    "Q605_concreting_gravel",
                                    "Q606_other_gravel",
                                    "Q607_constructional_fill"],
-                "distinct_values": ["region", "strata"]
+                "distinct_values": ["region", "strata"],
+                "RuntimeVariables": {"run_id": "runid"}
             }
 
             output = iqrs_method.lambda_handler(event, context_object)
@@ -147,7 +148,7 @@ class TestWranglerAndMethod():
                     mock_event,
                     context_object
                 )
-            assert "General Error" in exc_info.exception.error_message
+            assert "'Exception'" in exc_info.exception.error_message
 
     def test_method_general_exception(self):
         input_file = "tests/fixtures/Iqrs_with_columns.json"
@@ -161,7 +162,8 @@ class TestWranglerAndMethod():
                                    "Q605_concreting_gravel",
                                    "Q606_other_gravel",
                                    "Q607_constructional_fill"],
-                "distinct_values": "region, strata"
+                "distinct_values": "region, strata",
+                "RuntimeVariables": {"run_id": "runid"}
             }
             with mock.patch("iqrs_method.pd.DataFrame") as mocked:
                 mocked.side_effect = Exception("General exception")
@@ -172,7 +174,7 @@ class TestWranglerAndMethod():
 
                 assert "success" in response
                 assert response["success"] is False
-                assert """General exception""" in response["error"]
+                assert "'Exception'" in response["error"]
 
     @mock_sqs
     @mock_lambda
@@ -189,7 +191,7 @@ class TestWranglerAndMethod():
                         context_object,
                     )
 
-            assert "Key Error" in exc_info.exception.error_message
+            assert "KeyError" in exc_info.exception.error_message
 
     def test_method_key_error(self):
         with open("tests/fixtures/Iqrs_with_columns.json", "r") as file:
@@ -202,13 +204,14 @@ class TestWranglerAndMethod():
                                    "Q605_concreting_gravel",
                                    "Q606_other_gravel",
                                    "Q607_constructional_fill"],
-                "distinct_values": "'region', 'strata'"
+                "distinct_values": "'region', 'strata'",
+                "RuntimeVariables": {"run_id": "runid"}
             }
 
             response = iqrs_method.lambda_handler(
                 json_content, context_object
             )
-            assert """Key Error in""" in response["error"]
+            assert """KeyError""" in response["error"]
 
     def test_marshmallow_raises_wrangler_exception(self):
         """
@@ -237,7 +240,7 @@ class TestWranglerAndMethod():
                 iqrs_wrangler.lambda_handler(
                     mock_event, context_object
                 )
-            assert "AWS Error" in exc_info.exception.error_message
+            assert "ClientError" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_lambda
@@ -258,7 +261,7 @@ class TestWranglerAndMethod():
                             mock_event,
                             context_object,
                         )
-                    assert "Bad data" in exc_info.exception.error_message
+                    assert "AttributeError" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_lambda
@@ -280,7 +283,7 @@ class TestWranglerAndMethod():
                                 mock_event,
                                 context_object,
                             )
-                        assert "Incomplete Lambda response" in \
+                        assert "IncompleteReadError" in \
                                exc_info.exception.error_message
 
     @mock_sqs

--- a/tests/test_means.py
+++ b/tests/test_means.py
@@ -29,7 +29,8 @@ mock_event = {
                        'Q604_bituminous_gravel',
                        'Q605_concreting_gravel',
                        'Q606_other_gravel',
-                       'Q607_constructional_fill']
+                       'Q607_constructional_fill'],
+    "RuntimeVariables": {"run_id": "run_id"}
 }
 
 mock_wrangles_event = {
@@ -159,7 +160,7 @@ class TestMeans(unittest.TestCase):
                     context_object
                 )
 
-            assert "General Error" in exc_info.exception.error_message
+            assert "'Exception'" in exc_info.exception.error_message
 
     def test_method_general_exception(self):
         with mock.patch("calculate_means_method.pd.DataFrame") as mocked:
@@ -171,7 +172,7 @@ class TestMeans(unittest.TestCase):
 
             assert "success" in response
             assert response["success"] is False
-            assert """General exception""" in response["error"]
+            assert "'Exception'" in response["error"]
 
     @mock_sqs
     @mock_lambda
@@ -186,12 +187,12 @@ class TestMeans(unittest.TestCase):
                      mock_event,
                      context_object,
                 )
-            assert "Key Error" in exc_info.exception.error_message
+            assert "KeyError" in exc_info.exception.error_message
 
     def test_method_key_error(self):
         # pass none value to trigger key index error
         response = calculate_means_method.lambda_handler({"mike": "mike"}, context_object)
-        assert """Key Error""" in response["error"]
+        assert "KeyError" in response["error"]
 
     def test_marshmallow_raises_wrangler_exception(self):
         """
@@ -219,7 +220,7 @@ class TestMeans(unittest.TestCase):
                 calculate_means_wrangler.lambda_handler(
                     mock_wrangles_event, context_object
                 )
-            assert "AWS Error" in exc_info.exception.error_message
+            assert "ClientError" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_lambda
@@ -241,7 +242,7 @@ class TestMeans(unittest.TestCase):
                             mock_wrangles_event,
                             context_object,
                         )
-                    assert "Bad data" in exc_info.exception.error_message
+                    assert "AttributeError" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_lambda
@@ -264,7 +265,7 @@ class TestMeans(unittest.TestCase):
                                 mock_wrangles_event,
                                 context_object,
                             )
-                        assert "Incomplete Lambda response" \
+                        assert "IncompleteReadError" \
                                in exc_info.exception.error_message
 
     @mock_sqs

--- a/tests/test_recalculate_means.py
+++ b/tests/test_recalculate_means.py
@@ -136,7 +136,7 @@ class TestRecalculateMeans(unittest.TestCase):
                 self, exception_classes.LambdaFailure) as exc_info:
             recalculate_means_wrangler.lambda_handler(mock_wrangles_event,
                                                       context_object)
-        assert "AWS Error" in exc_info.exception.error_message
+        assert "ClientError" in exc_info.exception.error_message
 
     @mock_sqs
     def test_marshmallow_raises_wrangler_exception(self):
@@ -165,7 +165,7 @@ class TestRecalculateMeans(unittest.TestCase):
                 self, exception_classes.LambdaFailure) as exc_info:
             recalculate_means_wrangler.lambda_handler(
                 mock_wrangles_event, context_object)
-        assert "AWS Error" in exc_info.exception.error_message
+        assert "ClientError" in exc_info.exception.error_message
 
     @mock_sqs
     def test_attribute_error(self):
@@ -183,7 +183,7 @@ class TestRecalculateMeans(unittest.TestCase):
                         self, exception_classes.LambdaFailure) as exc_info:
                     recalculate_means_wrangler.lambda_handler(mock_wrangles_event,
                                                               context_object)
-                assert "Bad data" in exc_info.exception.error_message
+                assert "AttributeError" in exc_info.exception.error_message
 
     @mock_sqs
     def test_key_error(self):
@@ -200,7 +200,7 @@ class TestRecalculateMeans(unittest.TestCase):
                 recalculate_means_wrangler.lambda_handler(mock_wrangles_event,
                                                           context_object)
 
-        assert "Key Error" in exc_info.exception.error_message
+        assert "KeyError" in exc_info.exception.error_message
 
     @mock_sqs
     def test_general_exception(self):
@@ -215,9 +215,9 @@ class TestRecalculateMeans(unittest.TestCase):
                 with unittest.TestCase.assertRaises(
                         self, exception_classes.LambdaFailure) as exc_info:
                     recalculate_means_wrangler.lambda_handler(
-                        "", context_object
+                        mock_wrangles_event, context_object
                     )
-                assert "General Error in" in exc_info.exception.error_message
+                assert "'Exception'" in exc_info.exception.error_message
 
     @mock_sqs
     @mock_lambda
@@ -242,7 +242,7 @@ class TestRecalculateMeans(unittest.TestCase):
                                 mock_wrangles_event,
                                 context_object,
                             )
-                        assert "Incomplete Lambda response" \
+                        assert "IncompleteReadError" \
                                in exc_info.exception.error_message
 
     @mock_sqs


### PR DESCRIPTION
Generic error handling in all modules and tests updated to match. The wranglers now all send the runid to the method.

Methods now all use the funk layer so i've updated serverless yum to include the layer.
https://collaborate2.ons.gov.uk/jira/browse/LU-5463