### PR TITLE
Marshmallow_Update

### DIFF
--- a/add_regionless_method.py
+++ b/add_regionless_method.py
@@ -2,10 +2,17 @@ import logging
 
 import pandas as pd
 from es_aws_functions import general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     data = fields.List(fields.Dict, required=True)
     region_column = fields.Str(required=True)
     regionless_code = fields.Int(required=True)
@@ -30,10 +37,7 @@ def lambda_handler(event, context):
         # Because it is used in exception handling
         run_id = event["RuntimeVariables"]["run_id"]
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/apply_factors_wrangler.py
+++ b/apply_factors_wrangler.py
@@ -5,13 +5,20 @@ import os
 import boto3
 import pandas as pd
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 from marshmallow.validate import Equal
 
 from imputation_functions import produce_columns
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     bucket_name = fields.Str(required=True)
     checkpoint = fields.Str(required=True)
     method_name = fields.Str(required=True)
@@ -25,6 +32,13 @@ class FactorsSchema(Schema):
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     current_data = fields.Str(required=True)
     distinct_values = fields.List(fields.String, required=True)
     factors_parameters = fields.Dict(
@@ -66,15 +80,9 @@ def lambda_handler(event, context):
         sqs = boto3.client("sqs", "eu-west-2")
         lambda_client = boto3.client("lambda", region_name="eu-west-2")
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/atypicals_method.py
+++ b/atypicals_method.py
@@ -3,12 +3,19 @@ import logging
 import numpy as np
 import pandas as pd
 from es_aws_functions import general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 import imputation_functions as imp_func
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     data = fields.List(fields.Dict, required=True)
     questions_list = fields.List(fields.String, required=True)
 
@@ -31,10 +38,7 @@ def lambda_handler(event, context):
         # Because it is used in exception handling
         run_id = event["RuntimeVariables"]["run_id"]
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/atypicals_wrangler.py
+++ b/atypicals_wrangler.py
@@ -4,12 +4,19 @@ import os
 
 import boto3
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 import imputation_functions as imp_func
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     bucket_name = fields.Str(required=True)
     checkpoint = fields.Str(required=True)
     method_name = fields.Str(required=True)
@@ -17,6 +24,13 @@ class EnvironmentSchema(Schema):
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     in_file_name = fields.Str(required=True)
     incoming_message_group_id = fields.Str(required=True)
     location = fields.Str(required=True)
@@ -53,15 +67,9 @@ def lambda_handler(event, context):
         sqs = boto3.client("sqs", region_name="eu-west-2")
         lambda_client = boto3.client("lambda", region_name="eu-west-2")
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/calculate_imputation_factors_method.py
+++ b/calculate_imputation_factors_method.py
@@ -2,12 +2,19 @@ import logging
 
 import pandas as pd
 from es_aws_functions import general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 import imputation_functions as imp_func
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     data = fields.List(fields.Dict, required=True)
     distinct_values = fields.List(fields.String, required=True)
     factors_parameters = fields.Dict(required=True)
@@ -33,10 +40,7 @@ def lambda_handler(event, context):
         # Because it is used in exception handling
         run_id = event["RuntimeVariables"]["run_id"]
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         # Pick Correct Schema
         factors_parameters = runtime_variables["factors_parameters"]["RuntimeVariables"]
@@ -44,10 +48,7 @@ def lambda_handler(event, context):
         factors_name = ''.join(word.title() for word in factors_type.split('_'))
         factors_schema = getattr(imp_func, factors_name + "Schema")
 
-        factors, errors = factors_schema().load(factors_parameters)
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        factors = factors_schema().load(factors_parameters)
 
         logger.info("Validated parameters.")
 

--- a/calculate_imputation_factors_wrangler.py
+++ b/calculate_imputation_factors_wrangler.py
@@ -5,12 +5,19 @@ import os
 import boto3
 import pandas as pd
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 import imputation_functions as imp_func
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     bucket_name = fields.Str(required=True)
     checkpoint = fields.Str(required=True)
     method_name = fields.Str(required=True)
@@ -18,6 +25,13 @@ class EnvironmentSchema(Schema):
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     distinct_values = fields.List(fields.String, required=True)
     factors_parameters = fields.Dict(required=True)
     in_file_name = fields.Str(required=True)
@@ -56,15 +70,9 @@ def lambda_handler(event, context):
         sqs = boto3.client("sqs", region_name="eu-west-2")
         lambda_client = boto3.client("lambda", region_name="eu-west-2")
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/calculate_means_wrangler.py
+++ b/calculate_means_wrangler.py
@@ -4,12 +4,19 @@ import os
 
 import boto3
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 import imputation_functions as imp_func
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     bucket_name = fields.Str(required=True)
     checkpoint = fields.Str(required=True)
     method_name = fields.Str(required=True)
@@ -17,6 +24,13 @@ class EnvironmentSchema(Schema):
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     distinct_values = fields.List(fields.String, required=True)
     in_file_name = fields.Str(required=True)
     incoming_message_group_id = fields.Str(required=True)
@@ -54,15 +68,9 @@ def lambda_handler(event, context):
         sqs = boto3.client("sqs", region_name="eu-west-2")
         lambda_client = boto3.client("lambda", region_name="eu-west-2")
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/calculate_movement_method.py
+++ b/calculate_movement_method.py
@@ -2,12 +2,19 @@ import logging
 
 import pandas as pd
 from es_aws_functions import general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 import imputation_functions as imp_func
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     movement_type = fields.Str(required=True)
     data = fields.List(fields.Dict, required=True)
     questions_list = fields.List(fields.String, required=True)
@@ -35,10 +42,7 @@ def lambda_handler(event, context):
         # Because it is used in exception handling
         run_id = event["RuntimeVariables"]["run_id"]
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/calculate_movement_wrangler.py
+++ b/calculate_movement_wrangler.py
@@ -5,10 +5,17 @@ import os
 import boto3
 import pandas as pd
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     bucket_name = fields.Str(required=True)
     checkpoint = fields.Str(required=True)
     method_name = fields.Str(required=True)
@@ -16,6 +23,13 @@ class EnvironmentSchema(Schema):
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     current_data = fields.Str(required=True)
     in_file_name = fields.Str(required=True)
     incoming_message_group_id = fields.Str(required=True)
@@ -64,15 +78,9 @@ def lambda_handler(event, context):
         lambda_client = boto3.client("lambda", region_name="eu-west-2")
         logger.info("Setting-up environment configs")
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -52,7 +52,7 @@ jsonpickle==1.2
 jsonpointer==2.0
 jsonschema==2.6.0
 markupsafe==1.1.1
-marshmallow==2.19.5
+marshmallow==3.6.0
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==7.0.0 ; python_version > '2.7'

--- a/imputation_functions.py
+++ b/imputation_functions.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 
 import pandas as pd
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class FactorsSchema(Schema):
@@ -12,6 +12,12 @@ class FactorsSchema(Schema):
 
 
 class FactorsCalculationASchema(FactorsSchema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        raise ValueError(f"Error validating runtime params: {e}")
+
     first_imputation_factor = fields.Int(required=True)
     first_threshold = fields.Int(required=True)
     percentage_movement = fields.Bool(required=True)
@@ -21,6 +27,12 @@ class FactorsCalculationASchema(FactorsSchema):
 
 
 class FactorsCalculationBSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        raise ValueError(f"Error validating runtime params: {e}")
+
     threshold = fields.Int(required=True)
 
 
@@ -80,9 +92,7 @@ def factors_calculation_a(row, questions, **kwargs):
     :return: row of DataFrame
     """
 
-    runtime_variables, errors = ExtendedFactorsCalculationASchema().load(kwargs)
-    if errors:
-        raise ValueError(f"Error validating factors params: {errors}")
+    runtime_variables = ExtendedFactorsCalculationASchema().load(kwargs)
 
     runtime_object = SimpleNamespace(**runtime_variables)
 
@@ -163,9 +173,7 @@ def factors_calculation_b(row, questions, **kwargs):
 
     :return: row of DataFrame
     """
-    runtime_variables, errors = FactorsCalculationBSchema().load(kwargs)
-    if errors:
-        raise ValueError(f"Error validating factors params: {errors}")
+    runtime_variables = FactorsCalculationBSchema().load(kwargs)
 
     runtime_object = SimpleNamespace(**runtime_variables)
 

--- a/iqrs_method.py
+++ b/iqrs_method.py
@@ -2,12 +2,19 @@ import logging
 
 import pandas as pd
 from es_aws_functions import general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 from imputation_functions import produce_columns
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     data = fields.List(fields.Dict, required=True)
     distinct_values = fields.List(fields.String, required=True)
     questions_list = fields.List(fields.String, required=True)
@@ -32,10 +39,7 @@ def lambda_handler(event, context):
         # Because it is used in exception handling
         run_id = event["RuntimeVariables"]["run_id"]
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/iqrs_wrangler.py
+++ b/iqrs_wrangler.py
@@ -4,12 +4,19 @@ import os
 
 import boto3
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 import imputation_functions as imp_func
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     bucket_name = fields.Str(required=True)
     checkpoint = fields.Str(required=True)
     method_name = fields.Str(required=True)
@@ -17,6 +24,13 @@ class EnvironmentSchema(Schema):
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     distinct_values = fields.List(fields.String, required=True)
     in_file_name = fields.Str(required=True)
     incoming_message_group_id = fields.Str(required=True)
@@ -53,15 +67,9 @@ def lambda_handler(event, context):
         sqs = boto3.client("sqs", region_name="eu-west-2")
         lambda_client = boto3.client("lambda", region_name="eu-west-2")
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/recalculate_means_wrangler.py
+++ b/recalculate_means_wrangler.py
@@ -4,10 +4,17 @@ import os
 
 import boto3
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     bucket_name = fields.Str(required=True)
     checkpoint = fields.Str(required=True)
     method_name = fields.Str(required=True)
@@ -15,6 +22,13 @@ class EnvironmentSchema(Schema):
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     distinct_values = fields.List(fields.String, required=True)
     in_file_name = fields.Str(required=True)
     incoming_message_group_id = fields.Str(required=True)
@@ -52,15 +66,9 @@ def lambda_handler(event, context):
         sqs = boto3.client("sqs", "eu-west-2")
         lambda_client = boto3.client("lambda", "eu-west-2")
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 


### PR DESCRIPTION
Moving Marshmallow on from 2.19.5 to 3.6.0 because support for 2.19.5 ends on 18/08/2020.

Updates are fairly straightforward:
Add meta class so that excess variables are excluded.

Override the basic Marshmallow Error with out custom one. This moved it out of the main code block and into the Schema itself.