### PR TITLE
Better error message if all were non-respondents

### DIFF
--- a/calculate_movement_wrangler.py
+++ b/calculate_movement_wrangler.py
@@ -161,7 +161,11 @@ def lambda_handler(event, context):
             # Merged together so it can be sent via the payload to the method
             merged_data = pd.concat([data, previous_period_data])
 
-            logger.info("Successfully filtered and merged the previous period data")
+            # Make sure there is some data, non-responders were removed at this stage
+            if len(merged_data.index) > 0:
+                logger.info("Successfully filtered and merged the previous period data")
+            else:
+                raise exception_classes.LambdaFailure("No data left after filtering")
 
             for question in questions_list:
                 merged_data["movement_" + question] = 0.0


### PR DESCRIPTION
As all non-respondents are filtered out there is a chance that the filtered data frame will be empty. Should this happen a nice error message should be displayed instead of the random 'key-error' that we get currently.